### PR TITLE
Mention that the font is licensed under OFL 1.1, not 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This tool can be installed once in your computer and can be used thereafter to t
 ☛ [Keyboard layout in details] (https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sat-InScript2)
 
 ## Attribution:
-* The typeface and some of the font-related documentations were created by [Pooja Saxena] (https://github.com/anexasajoop), and the typeface is licensed under Open Font License (OFL) 1.0
+* The typeface and some of the font-related documentations were created by [Pooja Saxena] (https://github.com/anexasajoop), and the typeface is licensed under Open Font License (OFL) 1.1
 * The software and the source code, that are licensed under CC1.0, were created by [Jnanaranjan Sahu] (https://github.com/gyan111/) and [Nasim Ali] (https://github.com/coldbreeze16) under the ambit of the Project Ol Chiki, commissioned by the Centre for Internet and Society's Access to Knowledge (CIS-A2K)
 * Typeface reviewers: Prof. Damayanti Beshra, Malati Murmu and Mangat Murmu, Kuanra Murmu, and Raj Narayan Marndi
 * Project coordinated and maintained by [Subhashish Panigrahi] (http://www.github.com/psubhashish). All the project documentations here are released under CC1.0


### PR DESCRIPTION
Before this change, the README said “the typeface is licensed under
Open Font License (OFL) 1.0”. But the license string in the Glyphs
source for the font actually contains: “This Font Software is licensed
under the SIL Open Font License Version 1.1. This license is available
with a FAQ at http://scripts.sil.org/OFL”. OFL 1.1 is also much more
commonly used than 1.0, so it’s probably a typo in the README.